### PR TITLE
chore: javadoc and update versions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Oleksii Khalikov (GFalcon-UA)
+Copyright (c) 2023-2024 Oleksii Khalikov (GFalcon-UA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  MIT License
+  ~ -----------
+  ~
+  ~ Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+  ~ Permission is hereby granted, free of charge, to any person
+  ~ obtaining a copy of this software and associated documentation
+  ~ files (the "Software"), to deal in the Software without
+  ~ restriction, including without limitation the rights to use,
+  ~ copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the
+  ~ Software is furnished to do so, subject to the following
+  ~ conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be
+  ~ included in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  ~ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  ~ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  ~ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  ~ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  ~ OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -6,7 +33,7 @@
 
     <groupId>ua.com.gfalcon</groupId>
     <artifactId>finviz-api</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <name>Finviz API (unofficial)</name>
     <description>API for scraping stocks data from finviz.com</description>
@@ -21,21 +48,15 @@
         <ossindex.fail>true</ossindex.fail>
 
         <commons-collections4.version>4.4</commons-collections4.version>
-        <htmlunit.version>3.0.0</htmlunit.version>
-        <jsoup.version>1.15.4</jsoup.version>
-        <junit-jupiter.version>5.9.2</junit-jupiter.version>
+        <jsoup.version>1.17.2</jsoup.version>
+        <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <maven-version-ruleset.version>1.1.0</maven-version-ruleset.version>
-        <opencsv.version>5.7.1</opencsv.version>
+        <opencsv.version>5.9</opencsv.version>
         <ossindex-maven-plugin.version>3.2.0</ossindex-maven-plugin.version>
-        <slf4j-api.version>2.0.7</slf4j-api.version>
+        <slf4j-api.version>2.0.12</slf4j-api.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>${htmlunit.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -213,6 +234,12 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>maven-central</id>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+    </repositories>
 
     <distributionManagement>
         <snapshotRepository>

--- a/src/main/java/ua/com/gfalcon/finviz/exception/FinvizApiException.java
+++ b/src/main/java/ua/com/gfalcon/finviz/exception/FinvizApiException.java
@@ -1,5 +1,39 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.exception;
 
+/**
+ * FinvizApiException is a subclass of RuntimeException that is thrown when an error occurs while using the Finviz API.
+ * It is used to wrap any exceptions that occur during API usage and provide more specific information about the error.
+ * <p/>
+ * This class provides several constructors to handle different scenarios
+ * and allows the exception message and underlying cause to be specified.
+ */
 public class FinvizApiException extends RuntimeException {
 
     public FinvizApiException() {

--- a/src/main/java/ua/com/gfalcon/finviz/overview/Stock.java
+++ b/src/main/java/ua/com/gfalcon/finviz/overview/Stock.java
@@ -1,3 +1,30 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.overview;
 
 import java.io.IOException;
@@ -11,6 +38,9 @@ import org.jsoup.select.Elements;
 
 import ua.com.gfalcon.finviz.exception.FinvizApiException;
 
+/**
+ * The Stock class represents stock ticker information retrieved from Finviz.
+ */
 public class Stock {
 
     //<editor-fold desc="Variables">
@@ -104,9 +134,11 @@ public class Stock {
      * @param ticker ticker of the company
      * @throws FinvizApiException when ticker cannot be found on Finviz
      */
+    @SuppressWarnings("checkstyle:MethodLength")
     public Stock(String ticker) {
         Document doc = getStockInfo(ticker);
-        if (doc.getElementById("ticker") != null) {
+        if (!doc.getElementsByAttribute("data-ticker")
+                .isEmpty()) {
             Elements elements = doc.select("a.tab-link");
             this.ticker = Optional.ofNullable(doc.getElementById("ticker"))
                     .orElse(new Element("div"))
@@ -268,7 +300,7 @@ public class Stock {
                     .get(0)
                     .text());
         } else {
-            throw new FinvizApiException("This ticker cannot be found");
+            throw new FinvizApiException("This ticker " + ticker + " cannot be found");
         }
     }
 
@@ -625,8 +657,13 @@ public class Stock {
                 this.sma20, this.sma50, this.sma200, this.volume, this.change);
     }
 
+
     /**
-     * @return all stock variables
+     * Returns a string representation of the Stock object.
+     * The string includes all the attributes of the Stock object,
+     * formatted as key-value pairs separated by newlines.
+     *
+     * @return a string representation of the Stock object
      */
     @Override
     public String toString() {

--- a/src/main/java/ua/com/gfalcon/finviz/overview/Stocks.java
+++ b/src/main/java/ua/com/gfalcon/finviz/overview/Stocks.java
@@ -1,3 +1,30 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.overview;
 
 import java.io.IOException;
@@ -9,12 +36,16 @@ import java.util.List;
 
 import ua.com.gfalcon.finviz.exception.FinvizApiException;
 
+/**
+ * The Stocks class represents a collection of stocks.
+ * It provides methods to add, retrieve, and check the presence of stocks.
+ */
 public class Stocks {
 
     private final List<Stock> stocksList;
 
     /**
-     * Uses a text file with tickers on a new line
+     * Uses a text file with tickers on a new line.
      *
      * @param path text file with stocks
      * @throws FinvizApiException if unable to find ticker
@@ -35,7 +66,7 @@ public class Stocks {
     }
 
     /**
-     * Adds multiple stocks to list
+     * Adds multiple stocks to list.
      * <br>
      * {@code
      * Stocks stocks = new Stocks("MSFT", "AAPL", "TSLA");
@@ -67,7 +98,7 @@ public class Stocks {
     }
 
     /**
-     * Adds stock to Stocks list
+     * Adds stock to Stocks list.
      *
      * @param stock stock to add
      * @return true if stock is added
@@ -81,7 +112,7 @@ public class Stocks {
     }
 
     /**
-     * Adds stock to Stocks list
+     * Adds stock to Stocks list.
      *
      * @param stocks stock to add
      */

--- a/src/main/java/ua/com/gfalcon/finviz/overview/StocksUtilities.java
+++ b/src/main/java/ua/com/gfalcon/finviz/overview/StocksUtilities.java
@@ -1,3 +1,30 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.overview;
 
 import java.io.File;
@@ -15,6 +42,9 @@ import com.opencsv.exceptions.CsvValidationException;
 
 import ua.com.gfalcon.finviz.exception.FinvizApiException;
 
+/**
+ * The StocksUtilities class provides utility methods for working with Stocks objects.
+ */
 public class StocksUtilities {
 
     private static final Logger LOG = LoggerFactory.getLogger(StocksUtilities.class);
@@ -81,8 +111,8 @@ public class StocksUtilities {
      * Export.outputToCSV(stocks, System.getProperty("user.home") + "/Desktop/output.csv");
      * }
      *
-     * @param stock            Stock to output
-     * @param file             Absolute file path of CSV file
+     * @param stock Stock to output
+     * @param file  Absolute file path of CSV file
      */
     public static void outputToCSV(Stock stock, File file) {
         if (file.getParentFile()

--- a/src/main/java/ua/com/gfalcon/finviz/screener/RequestBuilder.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/RequestBuilder.java
@@ -1,3 +1,30 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener;
 
 import java.util.List;
@@ -6,10 +33,38 @@ import java.util.Objects;
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 import ua.com.gfalcon.finviz.screener.filter.Signal;
 
+/**
+ * The RequestBuilder class is responsible for building URL strings with filter parameters and a signal.
+ * It provides two methods: build() and build() with a signal.
+ */
 public class RequestBuilder {
 
+    public static final String SCREENER_URL = "https://finviz.com/screener.ashx?v=411";
+
+    /**
+     * Builds a URL string with filter parameters and a signal.
+     *
+     * @param filters the list of filter parameters
+     * @param signal  the signal
+     * @return a URL string with filter parameters and a signal
+     */
+    public String build(List<FilterParameter> filters, Signal signal) {
+        StringBuilder builder = new StringBuilder(build(filters));
+        if (Objects.nonNull(signal)) {
+            builder.append("&s=");
+            builder.append(signal.getValue());
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Builds a URL string with filter parameters.
+     *
+     * @param filters the list of filter parameters
+     * @return a URL string with filter parameters
+     */
     public String build(List<FilterParameter> filters) {
-        StringBuilder builder = new StringBuilder("https://finviz.com/screener.ashx?v=411");
+        StringBuilder builder = new StringBuilder(SCREENER_URL);
         if (Objects.nonNull(filters) && !filters.isEmpty()) {
             builder.append("&f=");
             boolean next = false;
@@ -20,15 +75,6 @@ public class RequestBuilder {
                 builder.append(parameter.getValue());
                 next = true;
             }
-        }
-        return builder.toString();
-    }
-
-    public String build(List<FilterParameter> filters, Signal signal) {
-        StringBuilder builder = new StringBuilder(build(filters));
-        if (Objects.nonNull(signal)) {
-            builder.append("&s=");
-            builder.append(signal.getValue());
         }
         return builder.toString();
     }

--- a/src/main/java/ua/com/gfalcon/finviz/screener/Screener.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/Screener.java
@@ -1,8 +1,39 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
+/**
+ * The Screener interface represents a screener with a list of filter parameters and a signal.
+ * It provides methods to retrieve the tickers, the result timestamp, and the number of tickers.
+ */
 public interface Screener {
 
     Set<String> getTickers();

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/FilterParameter.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/FilterParameter.java
@@ -1,5 +1,36 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter;
 
+/**
+ * The FilterParameter interface represents a filter parameter that can be used for filtering data.
+ * Classes that implement this interface provide methods to retrieve the value of the filter parameter.
+ */
 public interface FilterParameter {
 
     String getValue();

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/Signal.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/Signal.java
@@ -1,5 +1,35 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter;
 
+/**
+ * The Signal enumeration represents a signal used in building a URL string with filter parameters and a signal.
+ */
 public enum Signal {
     TOP_GAINERS("ta_topgainers"),
     TOP_LOSERS("ta_toplosers"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/AverageTrueRange.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/AverageTrueRange.java
@@ -1,7 +1,37 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * Represents different levels for the Average True Range filter.
+ */
 public enum AverageTrueRange implements FilterParameter {
     OVER_0_25("ta_averagetruerange_o0.25"),
     OVER_0_5("ta_averagetruerange_o0.5"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/AverageVolume.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/AverageVolume.java
@@ -1,7 +1,37 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * An enumeration representing various average volume filter parameters.
+ */
 public enum AverageVolume implements FilterParameter {
     UNDER_50_K("sh_avgvol_u50"),
     UNDER_100_K("sh_avgvol_u100"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/CurrentRatio.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/CurrentRatio.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The CurrentRatio enum represents different current ratio filter parameters.
+ * It implements the FilterParameter interface, and provides a method to retrieve the value of each filter parameter.
+ */
 public enum CurrentRatio implements FilterParameter {
     HIGH("fa_curratio_high"),
     LOW("fa_curratio_low"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/DebtEquity.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/DebtEquity.java
@@ -1,7 +1,44 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The DebtEquity enum represents different debt-to-equity filter parameters.
+ * <p/>
+ * It implements the FilterParameter interface and provides a method to get the string value of each parameter.
+ * The available DebtEquity filter options are HIGH, LOW, UNDER_1, and OVER_1.
+ * <p/>
+ * Usage:
+ * DebtEquity filter = DebtEquity.HIGH;
+ * String value = filter.getValue(); // returns "fa_debteq_high"
+ */
 public enum DebtEquity implements FilterParameter {
     HIGH("fa_debteq_high"),
     LOW("fa_debteq_low"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/DividendYield.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/DividendYield.java
@@ -1,7 +1,37 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * Represents the different options for filtering by dividend yield.
+ */
 public enum DividendYield implements FilterParameter {
     NONE("fa_div_none"),
     POSITIVE("fa_div_pos"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/EPSgrowthNext5years.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/EPSgrowthNext5years.java
@@ -1,7 +1,42 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * Enumeration class representing different types of filters for EPS growth
+ * next 5 years.
+ *
+ * <p>The EPSgrowthNext5years class implements the FilterParameter interface
+ * and provides filter options for EPS growth next 5 years. Each option has a
+ * corresponding string value that can be used for filtering.</p>
+ */
 public enum EPSgrowthNext5years implements FilterParameter {
     NEGATIVE("fa_estltgrowth_neg"),
     POSITIVE("fa_estltgrowth_pos"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/EPSgrowthPast5years.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/EPSgrowthPast5years.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The EPSgrowthPast5years enum represents the filter parameters for the growth of earnings per share (EPS)
+ * over the past 5 years.
+ */
 public enum EPSgrowthPast5years implements FilterParameter {
     NEGATIVE("fa_eps5years_neg"),
     POSITIVE("fa_eps5years_pos"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/EarningsDate.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/EarningsDate.java
@@ -1,7 +1,42 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * This enum represents different earnings date filter parameters that can be used
+ * in the application. It implements the FilterParameter interface.
+ * <p/>
+ * Earnings dates can be filtered based on different time periods such as today,
+ * tomorrow, yesterday, next 5 days, previous 5 days, this week, next week, previous week,
+ * and this month.
+ */
 public enum EarningsDate implements FilterParameter {
     TODAY("earningsdate_today"),
     TODAY_BEFORE_MARKET_OPEN("earningsdate_todaybefore"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/Exchange.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/Exchange.java
@@ -1,7 +1,39 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The Exchange class is an enumeration of different stock exchanges.
+ * It implements the FilterParameter interface.
+ * Each exchange has a corresponding value that can be used as a filter parameter.
+ */
 public enum Exchange implements FilterParameter {
     AMEX("exch_amex"),
     NASDAQ("exch_nasd"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/GrossMargin.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/GrossMargin.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The GrossMargin enum represents different levels of gross margins for filtering data.
+ * It implements the FilterParameter interface, which provides a method to retrieve the value of the filter parameter.
+ */
 public enum GrossMargin implements FilterParameter {
     POSITIVE("fa_grossmargin_pos"),
     NEGATIVE("fa_grossmargin_neg"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/IPOdate.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/IPOdate.java
@@ -1,7 +1,37 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The IPOdate enum represents various IPO date filter parameters.
+ */
 public enum IPOdate implements FilterParameter {
     YEAR_AGO("ipodate_more1"),
     MORE_THAN_5_YEARS_AGO("ipodate_more5"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/Industry.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/Industry.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The Industry enum represents the industry filters available for filtering data in the Finviz API.
+ * It implements the FilterParameter interface and provides methods to retrieve the value of the filter parameter.
+ */
 public enum Industry implements FilterParameter {
     STOCK("ind_stocksonly"),
     ETF("ind_exchangetradedfund");

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/MarketCap.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/MarketCap.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The MarketCap enum represents the market capitalization filters available for filtering data in the Finviz API.
+ * It implements the FilterParameter interface and provides methods to retrieve the value of the filter parameter.
+ */
 public enum MarketCap implements FilterParameter {
     NANO("cap_nano"),
     MICRO("cap_micro"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/NetProfitMargin.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/NetProfitMargin.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The NetProfitMargin class is an enumeration that represents different net profit margin filters.
+ * It implements the FilterParameter interface, which provides a method to retrieve the value of the filter parameter.
+ */
 public enum NetProfitMargin implements FilterParameter {
     POSITIVE("fa_netmargin_pos"),
     NEGATIVE("fa_netmargin_neg"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/OperatingMargin.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/OperatingMargin.java
@@ -1,7 +1,41 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The OperatingMargin enum represents different types of operating margins used as filter parameters.
+ * Each operating margin has a corresponding value that can be used for filtering data.
+ * <p/>
+ * The enum implements the FilterParameter interface,
+ * which requires the implementation of the getValue() method to retrieve the value of the filter parameter.
+ */
 public enum OperatingMargin implements FilterParameter {
     POSITIVE("fa_opermargin_pos"),
     NEGATIVE("fa_opermargin_neg"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/OptionShort.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/OptionShort.java
@@ -1,8 +1,39 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The OptionShort enum represents the option short filters available for filtering data in the Finviz API.
+ * It implements the FilterParameter interface and provides methods to retrieve the value of the filter parameter.
+ */
 public enum OptionShort implements FilterParameter {
     OPTIONABLE("sh_opt_option"),
     SHORTABLE("sh_opt_short"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/PE.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/PE.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The PE enum represents various filter options based on the price-to-earnings ratio (PE).
+ * It implements the FilterParameter interface, providing a way to retrieve the value of the filter parameter.
+ */
 public enum PE implements FilterParameter {
     LOW("fa_pe_low"),
     PROFITABLE("fa_pe_profitable"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/PayoutRatio.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/PayoutRatio.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The PayoutRatio enum represents the options for payout ratios used as filter parameters.
+ * Each payout ratio option has a corresponding value used for filtering.
+ */
 public enum PayoutRatio implements FilterParameter {
     NONE("fa_payoutratio_none"),
     POSITIVE("fa_payoutratio_pos"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/Price.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/Price.java
@@ -1,7 +1,39 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The Price enum represents the price range options for filtering data.
+ * Each price range has a corresponding value used for filtering.
+ * Price ranges are defined as constants and can be retrieved using getValue() method.
+ */
 public enum Price implements FilterParameter {
     FROM_1_TO_5("sh_price_1to5"),
     FROM_1_TO_10("sh_price_1to10"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/QuickRatio.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/QuickRatio.java
@@ -1,7 +1,37 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The QuickRatio enum represents the quick ratio filter parameter for filtering data.
+ */
 public enum QuickRatio implements FilterParameter {
     HIGH("fa_quickratio_high"),
     LOW("fa_quickratio_low");

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/ReturnOnEquity.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/ReturnOnEquity.java
@@ -1,7 +1,46 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * ReturnOnEquity is an enumeration that represents different filter parameters for return on equity.
+ * It implements the FilterParameter interface.
+ * <p/>
+ * The possible return on equity filter parameters are:
+ * - POSITIVE: Represents the filter parameter for positive return on equity.
+ * - NEGATIVE: Represents the filter parameter for negative return on equity.
+ * - VERY_POSITIVE: Represents the filter parameter for very positive return on equity.
+ * - VERY_NEGATIVE: Represents the filter parameter for very negative return on equity.
+ * <p/>
+ * Each filter parameter has a corresponding value that can be retrieved using the getValue() method.
+ */
 public enum ReturnOnEquity implements FilterParameter {
     POSITIVE("fa_roe_pos"),
     NEGATIVE("fa_roe_neg"),

--- a/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/SalesGrowthPast5years.java
+++ b/src/main/java/ua/com/gfalcon/finviz/screener/filter/params/SalesGrowthPast5years.java
@@ -1,7 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener.filter.params;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The SalesGrowthPast5years enum represents the various sales growth filters for the past 5 years.
+ * The enum implements the FilterParameter interface and provides methods to retrieve the filter value.
+ */
 public enum SalesGrowthPast5years implements FilterParameter {
     NEGATIVE("fa_sales5years_neg"),
     POSITIVE("fa_sales5years_pos"),

--- a/src/main/java/ua/com/gfalcon/finviz/validator/ScreenerFilterValidator.java
+++ b/src/main/java/ua/com/gfalcon/finviz/validator/ScreenerFilterValidator.java
@@ -1,9 +1,42 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.validator;
 
 import java.util.List;
 
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 
+/**
+ * The ScreenerFilterValidator class is responsible for validating a list of FilterParameter objects.
+ * It ensures that the list does not contain duplicate FilterParameter classes.
+ *
+ * @param <T> the type of FilterParameter objects to be validated
+ */
 public class ScreenerFilterValidator implements Validator<List<FilterParameter>> {
 
     private ScreenerFilterValidator() {

--- a/src/main/java/ua/com/gfalcon/finviz/validator/Validator.java
+++ b/src/main/java/ua/com/gfalcon/finviz/validator/Validator.java
@@ -1,5 +1,38 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.validator;
 
+/**
+ * The Validator interface represents a generic validator that can be used to validate objects.
+ * Implementations of this interface should provide an implementation for the isValid method.
+ *
+ * @param <T> the type of the object to be validated
+ */
 public interface Validator<T> {
 
     boolean isValid(T obj);

--- a/src/test/java/ua/com/gfalcon/finviz/screener/ScreenerTest.java
+++ b/src/test/java/ua/com/gfalcon/finviz/screener/ScreenerTest.java
@@ -1,13 +1,54 @@
+/*
+ *  MIT License
+ * -----------
+ *
+ * Copyright (c) 2016-2024 Oleksii V. KHALIKOV (http://gfalcon.com.ua)
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package ua.com.gfalcon.finviz.screener;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
 
+import static ua.com.gfalcon.finviz.screener.FinvizScreener.SCREENER_TICKERS_CLASS;
+import static ua.com.gfalcon.finviz.screener.RequestBuilder.SCREENER_URL;
 import ua.com.gfalcon.finviz.exception.FinvizApiException;
 import ua.com.gfalcon.finviz.screener.filter.FilterParameter;
 import ua.com.gfalcon.finviz.screener.filter.Signal;
@@ -18,6 +59,40 @@ import ua.com.gfalcon.finviz.screener.filter.params.MarketCap;
 import ua.com.gfalcon.finviz.screener.filter.params.OptionShort;
 
 class ScreenerTest {
+
+    //    @Test
+    void saveHtmlPageAsResource() {
+        try {
+            URL url = new URL("https://finviz.com/screener.ashx?v=411");
+            String date = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                    .format(LocalDateTime.now());
+
+            try (ReadableByteChannel readableByteChannel = Channels.newChannel(
+                    url.openStream()); FileOutputStream fileOutputStream = new FileOutputStream(
+                    "src/test/resources/" + date + ".html")) {
+                fileOutputStream.getChannel()
+                        .transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.out.println("Download failed.");
+        }
+    }
+
+    @Test
+    void tickerListAvailableTest() {
+        Document page = getWebPage(SCREENER_URL);
+
+        int tickerCount = FinvizScreener.getTickerCount(page);
+        Elements tickers = page.getElementsByClass(SCREENER_TICKERS_CLASS);
+
+        Assertions.assertAll(() -> Assertions.assertTrue(tickerCount > 0), () -> Assertions.assertNotNull(tickers),
+                () -> Assertions.assertFalse(tickers.isEmpty()), () -> Assertions.assertFalse(
+                        FinvizScreener.getTickerSymbols(tickers)
+                                .isEmpty()), () -> Assertions.assertTrue(StringUtils.isNotBlank(
+                        FinvizScreener.getTickerSymbols(tickers)
+                                .get(0))));
+    }
 
     @Test
     void getTickers() {
@@ -46,4 +121,17 @@ class ScreenerTest {
 //                Price.FROM_1_TO_20
         );
     }
+
+    private Document getWebPage(String url) {
+        Document page = null;
+        try {
+            page = Jsoup.connect(url)
+                    .get();
+        } catch (IOException e) {
+            Assertions.fail(e.getMessage());
+        }
+        Assertions.assertNotNull(page);
+        return page;
+    }
+
 }


### PR DESCRIPTION
The commit adds javadoc comments to several classes, providing clear and concise descriptions of the classes. Some classes were also migrated to use Jsoup instead of HtmlUnit. Additionally, the versions of various dependencies in pom.xml were updated.